### PR TITLE
Зміни вигляду помилки якщо ЄДРПОУ не знайдений

### DIFF
--- a/openprocurement/integrations/edr/tests/verify.py
+++ b/openprocurement/integrations/edr/tests/verify.py
@@ -127,7 +127,7 @@ class TestVerify(BaseWebTest):
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.status, '404 Not Found')
         self.assertEqual(response.json['errors'][0]['description'],
-                         [{u'message': u'EDRPOU not found',
+                         [{u'error': {u'errorDetails': u"Couldn't find this code in EDR.", u'code': u'notFound'},
                            u'meta': {u'sourceDate': u'2017-04-25T11:56:36+00:00'}}])
 
     def test_unauthorized(self):

--- a/openprocurement/integrations/edr/views/verify.py
+++ b/openprocurement/integrations/edr/views/verify.py
@@ -44,7 +44,8 @@ def verify_user(request):
         data = response.json()
         if not data:
             LOGGER.warning('Accept empty response from EDR service for {}'.format(details.code))
-            return handle_error(request, [{u'message': u'EDRPOU not found',
+            return handle_error(request, [{u"error": {u"errorDetails": u"Couldn't find this code in EDR.",
+                                                      u"code": u"notFound"},
                                            u'meta': meta_data(response.headers['Date'])}], 404)
         LOGGER.info('Return data from EDR service for {}'.format(details.code))
         return {'data': [prepare_data(d) for d in data], 'meta': meta_data(response.headers['Date'])}


### PR DESCRIPTION
Змінили вигляд помилки з {'message': 'EDRPOU not found',} на {"error": {"errorDetails": "Couldn't find this code in EDR.", "code": "notFound"}} для не знайденого ЄДРПОУ.
