### PR TITLE
Bugfix

### DIFF
--- a/openprocurement/integrations/edr/tests/verify.py
+++ b/openprocurement/integrations/edr/tests/verify.py
@@ -199,7 +199,7 @@ class TestVerify(BaseWebTest):
         self.assertEqual(response.status, '200 OK')
         self.assertTrue(self.redis.exists(db_key("14360570", "verify")))
         self.app.authorization = ('Basic', ('robot', 'robot'))
-        response = self.app.get('/verify?id=14360570')
+        response = self.app.get('/verify?id=14360570', expect_errors=True)
         expected_details_data = {u"additionalActivityKinds": [
             {u"scheme": u"КВЕД", u"id": u"64.92", u"description": u"Інші види кредитування"},
             {u"scheme": u"КВЕД", u"id": u"64.99",
@@ -219,11 +219,17 @@ class TestVerify(BaseWebTest):
                 {u"role_text": u"засновник", u"role": 4, u"name": u"АКЦІОНЕРИ - ЮРИДИЧНІ ТА ФІЗИЧНІ ОСОБИ"}],
             u"activityKind": {u"scheme": u"КВЕД", u"id": u"64.19",
                               u"description": u"Інші види грошового посередництва"}}
-        self.assertEqual(response.json['data'][0], expected_details_data)
-        response = self.app.get('/verify?id=14360570')
-        self.assertTrue(self.redis.exists(db_key("14360570", "details")))
-        self.assertEqual(response.json, loads(self.redis.get(db_key("14360570", "details"))))
-        self.assertEqual(loads(self.redis.get(db_key("14360570", "details")))['data'][0], expected_details_data)
+        if SANDBOX_MODE:
+            self.assertEqual(response.status, '404 Not Found')
+            self.assertEqual(response.json['errors'][0]['description'][0]['error']['errorDetails'],
+                             "Couldn't find this code in EDR.")
+            self.assertFalse(self.redis.exists(db_key("14360570", "details")))
+        else:
+            self.assertEqual(response.json['data'][0], expected_details_data)
+            response = self.app.get('/verify?id=14360570')
+            self.assertTrue(self.redis.exists(db_key("14360570", "details")))
+            self.assertEqual(response.json, loads(self.redis.get(db_key("14360570", "details"))))
+            self.assertEqual(loads(self.redis.get(db_key("14360570", "details")))['data'][0], expected_details_data)
 
     def test_not_acceptable(self):
         """Check 406 status EDR response"""
@@ -413,7 +419,6 @@ class TestDetails(BaseWebTest):
                               u"description": u"Інші види грошового посередництва"}}
         response = self.app.get('/verify?id=14360570', expect_errors=True)
         if SANDBOX_MODE:
-            self.assertTrue(self.redis.exists(db_key("14360570", "verify")))
             self.assertEqual(response.status, '404 Not Found')
             self.assertEqual(response.json['errors'][0]['description'][0]['error']['errorDetails'],
                              "Couldn't find this code in EDR.")
@@ -608,10 +613,6 @@ class TestDetails(BaseWebTest):
             self.assertEqual(response.json['data'], example_data)
             self.assertEqual(iso8601.parse_date(response.json['meta']['sourceDate']).replace(second=0, microsecond=0),
                              datetime.datetime.now(tz=TZ).replace(second=0, microsecond=0))
-            self.assertTrue(self.redis.exists(db_key("00037256", "details")))
-            response = self.app.get('/verify?id=00037256')
-            self.assertEqual(response.json['data'], example_data)
-            self.assertEqual(response.json, loads(self.redis.get("00037256_details_sandbox")))
         else:
             setup_routing(self.edr_api_app, func=sandbox_mode_data)
             setup_routing(self.edr_api_app, path='/1.0/subjects/999186', func=sandbox_mode_data_details)
@@ -621,3 +622,20 @@ class TestDetails(BaseWebTest):
             self.assertEqual(response.json['data'][0], example_data[0])
             self.assertEqual(response.json['meta'], {'sourceDate': '2017-04-25T11:56:36+00:00',
                                                      'detailsSourceDate': ['2017-04-25T11:56:36+00:00']})
+
+    def test_invalid_code(self):
+        """Check invalid EDRPOU(IPN) number 123"""
+        setup_routing(self.edr_api_app, func=response_code)
+        response = self.app.get('/verify?id=123', status=404)
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.status, '404 Not Found')
+        expected_result = [{u'error': {u'errorDetails': u"Couldn't find this code in EDR.", u'code': u'notFound'},
+                           u'meta': {u'sourceDate': u'2017-04-25T11:56:36+00:00'}}]
+        if SANDBOX_MODE:
+            self.assertEqual(response.json['errors'][0]['description'][0]['error']['errorDetails'],
+                             "Couldn't find this code in EDR.")
+        else:
+            self.assertTrue(self.redis.exists(db_key("123", "verify")))
+            self.assertEqual(response.json['errors'][0]['description'], expected_result)
+            response = self.app.get('/verify?id=123', status=404)
+            self.assertEqual(response.json, loads(self.redis.get(db_key("123", "verify"))))

--- a/openprocurement/integrations/edr/views/verify.py
+++ b/openprocurement/integrations/edr/views/verify.py
@@ -20,6 +20,9 @@ def verify_user(request):
                                  {"location": "url", "name": "id",
                                   "description": [{u'message': u'Wrong name of the GET parameter'}]})
         details = EDRDetails('passport', passport)
+    data = get_sandbox_data(request, code)  # return test data if SANDBOX_MODE=True and data exists for given code
+    if data:
+        return data
     if role == "robots":
         res = cached_details(request, details.code)
         if res:
@@ -28,9 +31,6 @@ def verify_user(request):
         return cached_verify(request, details.code)
     LOGGER.info("Code {} was not found in cache at {}".format(
         details.code, db_key(details.code, "details" if role == "robots" else "verify")))
-    data = get_sandbox_data(request, code)  # return test data if SANDBOX_MODE=True and data exists for given code
-    if data:
-        return data
     try:
         response = request.registry.edr_client.get_subject(**details._asdict())
     except (requests.exceptions.ReadTimeout,


### PR DESCRIPTION
Прибрано збереження тестових записів з пісочниці у кеш, так як воно ускладнювало логіку, не додаючи вагомих плюсів до продуктивності.